### PR TITLE
Makes bibtexparser conditional on --source, adds documentation, reorganizes folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
-# dialectica-scripts
-Scripts used the production of the open access journal dialectica
+# Dialectica Open Access Initiative scripts
+
+Scripts used the production of the open access journal [Dialectica](https://dialectica.philosophie.ch). Distributed as part of Dialectica's
+Open Access Initative.
+
+All scripts (c) 2021 their respective authors, under MIT License. See LICENSE file for details. 
+
+## Selfcites
+
+`Selfcites.py` checks whether a BibTex/BibLaTeX file contains self-citations, 
+adds them from a specified source if provided. Created by [Thomas Hodgson](https://github.com/twsh) 2021.
+
+
+
+
+

--- a/bibliographies/README.md
+++ b/bibliographies/README.md
@@ -1,4 +1,0 @@
-Bibliography tools
-==================
-
-This folder collects scripts used to manage bibliography databases and bibliography reference files.

--- a/bibliographies/selfcites.py
+++ b/bibliographies/selfcites.py
@@ -31,10 +31,7 @@ Dependencies:
 import argparse
 import os
 import re
-import bibtexparser
-
-from bibtexparser.bwriter import BibTexWriter
-from bibtexparser.bibdatabase import BibDatabase
+# import bibtexparser: below, depending on whether a --source argument is specified
 
 # Handle command line arguments
 parser = argparse.ArgumentParser(
@@ -55,6 +52,17 @@ parser.add_argument(
     default="_extended",
 )
 args = parser.parse_args()
+
+if args.source
+    import bibtexparser
+    from bibtexparser.bwriter import BibTexWriter
+    from bibtexparser.bibdatabase import BibDatabase
+
+# Print script information message
+print(
+    "Dialectica open access initiative self-citing bibliography file check\n",
+    "(c) Thomas Hodgson 2021",
+)
 
 
 for current_file in args.bibliographies:
@@ -78,10 +86,6 @@ for current_file in args.bibliographies:
         missing = self_keys - entries
 
         # Print the information
-        print(
-            "Dialectica open access initiative self-citing bibliography file check,",
-            "(c) Thomas Hodgson 2021",
-        )
         print("I'm checking: '{}'.".format(current_file))
 
         if self_keys:
@@ -101,7 +105,7 @@ for current_file in args.bibliographies:
                 print("There are no missing self-citing keys.")
 
         else:
-            print("I didn't find any keys self-citing other entries.")
+            print("I didn't find any self-citing keys.")
 
         if entries:
             print(
@@ -110,7 +114,7 @@ for current_file in args.bibliographies:
                 sep="\n",
             )
         else:
-            print("I didn't find any entries")
+            print("I didn't find any entries.")
 
         # Try to get the missing entries from the source bibliography
         if args.source and missing:

--- a/selfcites/Makefile
+++ b/selfcites/Makefile
@@ -1,0 +1,6 @@
+PHONY: test
+
+test: sample_completed.bib
+
+sample_completed.bib: selfcites.py sample.bib source.bib 
+	@python3 selfcites.py sample.bib --source source.bib --suffix _completed

--- a/selfcites/README.md
+++ b/selfcites/README.md
@@ -1,0 +1,64 @@
+Selfcites.py
+============
+
+Checks whether a BibTex/BibLaTeX file contains self-citations, 
+adds them from a specified source if provided.
+
+(c) Thomas Hodgson 2021, MIT License (see LICENSE file at this repository's root.)
+
+## Pre-requisites
+
+* Python 3, including some standard modules (`os`, `argparse`).
+* if using the script to supplement missing citations from a specificied
+  source, the [bibtexparser](https://bibtexparser.readthedocs.io/en/master/install.html#how-to-install) python package. This can be installed using
+  the package installer for python: run `pip3 install bibtexparser` on 
+  the command line.
+
+## Usage
+
+"BibTeX" below refers to both BibTeX and BibLaTeX files.
+
+### Checking if a BibTeX file contains self-citing keys and if any is missing
+
+Place the script `selfcites.py` in a suitable folder. On the command line:
+
+```
+python3 selfcites.py mybibliography.bib
+```
+
+The script will display the file's self-citing keys, if any, as a comma separated list. 
+
+Of course if the script and/or the `.bib` file are in different folders than
+the present working one, you should specify their paths, e.g.:
+
+```
+python3 ../resources/scripts/selfcites.py myarticle/mybibliography.bib
+```
+
+### Cecking several BibTeX files
+
+You can specify several files, or all BibTeX files at a given location:
+
+```
+python3 selfcites.py introduction.bib chapter1.bib
+python3 selfcites.py book/*.bib
+```
+
+### Adding missing entries from a specified source file, if found
+
+To look for and add any self-citing key's missing entries in a source bibliography file:
+
+```
+python3 selfcites.py mybibliography.bib --source masterbiblio.bib
+```
+
+The resulting bib file will be saved as `<yourbibfilename>_extended.bib`. You
+can specify a custom suffix instead of the default `_extended` with the 
+`--suffix` option:
+
+```
+python3 selfcites.py mybibliography.bib --source masterbiblio.bib --suffix "_finished"
+```
+
+
+

--- a/selfcites/sample.bib
+++ b/selfcites/sample.bib
@@ -1,0 +1,530 @@
+% Encoding: UTF-8
+
+
+@book{vanbenthem:1986,
+  address =       {Dordrecht},
+  author =        {van Benthem, Johan},
+  booktitle =     {Essays in Logical Semantics},
+  number =        {29},
+  publisher =     {D.~Reidel Publishing Co.},
+  series =        {Studies in Linguistics and Philosophy},
+  title =         {Essays in Logical Semantics},
+  year =          {1986},
+}
+
+@book{vanbenthem:1991,
+  address =       {Amsterdam},
+  author =        {van Benthem, Johan},
+  number =        {130},
+  publisher =     {North-Holland Publishing Co.},
+  series =        {Studies in Logic and the Foundations of Mathematics},
+  title =         {Language in Action: Categories, Lambdas, and Dynamic
+                   Logic},
+  year =          {1991},
+}
+
+@incollection{vanbenthem:2008,
+  address =       {London},
+  author =        {van Benthem, Johan},
+  booktitle =     {Logic, Navya-Ny{\=a}ya \& Applications. Hommage to
+                   Bimal Krishna Matilal},
+  editor =        {Chakraborty, Mihir K. and Löwe, Benedikt and
+                   Nath Mitra, Madhabendra and Surakkai, Sundar},
+  pages =         {21--42},
+  publisher =     {College Publications},
+  series =        {Studies in Logic},
+  title =         {Natural Logic: A View from the 1980s},
+  year =          {2008},
+}
+
+@book{benyami:2004,
+  address =       {Aldershot, Hampshire},
+  author =        {Ben-Yami, Hanoch},
+  publisher =     {Ashgate Publishing Limited},
+  title =         {Logic \& Natural Language. On Plural Reference and
+                   Its Semantic and Logical Significance},
+  year =          {2004},
+}
+
+@article{benyami:2009a,
+  author =        {Ben-Yami, Hanoch},
+  journal =       {Logique et Analyse},
+  number =        {208},
+  pages =         {309--326},
+  title =         {Generalized Quantifiers, and Beyond},
+  volume =        {52},
+  year =          {2009},
+}
+
+@Article{benyami:2014b,
+  author  = {Ben-Yami, Hanoch},
+  journal = {The Review of Symbolic Logic},
+  title   = {The Quantified Argument Calculus},
+  year    = {2014},
+  number  = {1},
+  pages   = {120--146},
+  volume  = {7},
+  doi     = {10.1017/s1755020313000373},
+}
+
+@article{benyami:forthcoming,
+  author =        {Ben-Yami, Hanoch},
+  journal =       {Synthese},
+  title =         {The Barcan Formulas and Necessary Existence: the View
+                   from Quarc},
+  year =          {forthcoming},
+}
+
+@unpublished{benyami-pavlovic:unpub,
+  author =        {Ben-Yami, Hanoch and Pavlovic, Edi},
+  note =          {Unpublished manuscript},
+  title =         {The Completeness of the Quantified Argument Calculus
+                   on the Truth-Valuational Approach},
+  year =          {2020},
+}
+
+@Article{cobreros-etal:2013a,
+  author  = {Cobreros, Pablo and {\'E}gr{\'e}, Paul and Ripley, David and van Rooij, Robert},
+  journal = {Mind},
+  title   = {Reaching Transparent Truth},
+  year    = {2013},
+  number  = {488},
+  pages   = {841--866},
+  volume  = {122},
+  doi     = {10.1093/mind/fzt110},
+}
+
+@book{fitch_fb:1952,
+  address =       {New York},
+  author =        {Fitch, Frederic B.},
+  publisher =     {Ronald Press Co.},
+  title =         {Symbolic Logic: An Introduction},
+  year =          {1952},
+}
+
+@Article{francez_i:2009,
+  author  = {Francez, Itamar},
+  journal = {Linguistics and Philosophy},
+  title   = {Existentials, Predication, and Modification},
+  year    = {2009},
+  number  = {1},
+  pages   = {1--50},
+  volume  = {32},
+  doi     = {10.1007/s10988-009-9055-4},
+}
+
+@book{frege:1879,
+  address =       {Halle a.S.},
+  author =        {Frege, Gottlob},
+  publisher =     {Louis Nebert},
+  title =         {Begriffsschrift, eine der arithmetischen
+                   nachgebildete Formelsprache des reinen Denkens},
+  year =          {1879},
+}
+
+@book{geach_pt:1962,
+  address =       {Ithaca, New York},
+  author =        {Geach, Peter Thomas},
+  note =          {third edition:~\citet{geach_pt:1980}},
+  publisher =     {Cornell University Press},
+  title =         {Reference and Generality, an examination of some
+                   medieval and modern theories},
+  year =          {1962},
+}
+
+@book{hallden:1949,
+  address =       {Uppsala},
+  author =        {Halld{\'e}n, S{\"o}ren},
+  publisher =     {Uppsala Universitet},
+  title =         {The Logic of Nonsense},
+  year =          {1949},
+}
+
+@Article{henkin:1949,
+  author  = {Henkin, Leon},
+  journal = {The Journal of Symbolic Logic},
+  title   = {The Completeness of the First-Order Functional Calculus},
+  year    = {1949},
+  number  = {3},
+  pages   = {159--166},
+  volume  = {14},
+  doi     = {10.2307/2267044},
+}
+
+@article{jaskowski:1934,
+  author =        {Ja{\'s}kowski, Stanis{\l}aw},
+  journal =       {Studia Logica (Poznan Panstwowe Wydawnictowo
+                   Naukowe)},
+  note =          {reprinted in \citet[232--258]{mccall_s:1967}, with
+                   considerable change in notation},
+  pages =         {5--32},
+  title =         {On the Rules of Suppositions in Formal Logic},
+  volume =        {1},
+  year =          {1934},
+}
+
+@incollection{lanzet_r-benyami:2004,
+  address =       {Berlin},
+  author =        {Lanzet, Ran and Ben-Yami, Hanoch},
+  booktitle =     {First-Order Logic Revisited},
+  editor =        {Hendricks, Vincent F. and Neuhaus, Fabian and
+                   Pedersen, Stig Andur and Scheffler, Uwe and
+                   Wansing, Heinrich},
+  number =        {12},
+  pages =         {173--224},
+  publisher =     {Logos Verlag},
+  series =        {Logische Philosophie},
+  title =         {Logical Inquiries into a New Formal System with
+                   Plural Reference},
+  year =          {2004},
+}
+
+@Article{lanzet_r:2017,
+  author   = {Lanzet, Ran},
+  journal  = {Linguistics and Philosophy},
+  title    = {A Three-Valued Quantified Argument Calculus: Domain-Free Model-Theory, Completeness, and Embedding of FOL},
+  year     = {2017},
+  number   = {2},
+  pages    = {207--234},
+  volume   = {30},
+  doi      = {10.1017/s1755020317000053},
+  num_sort = {73107},
+  topic    = {pragmatics;speech-acts;ok},
+}
+
+@book{lemmon:1978,
+  address =       {Indianapolis, Indiana},
+  author =        {Lemmon, Edward John},
+  note =          {first edition: \citet{lemmon:1965}},
+  publisher =     {Hackett Publishing Co.},
+  title =         {Beginning Logic},
+  year =          {1978},
+}
+
+@Article{lewis_ha:1985a,
+  author  = {Lewis, Harry A.},
+  journal = {No{\^u}s},
+  title   = {Substitutional Quantification and Nonstandard Quantifiers},
+  year    = {1985},
+  number  = {3},
+  pages   = {447--451},
+  volume  = {19},
+  doi     = {10.2307/2214953},
+}
+
+@incollection{mcnally_l:2011,
+  address =       {Berlin},
+  author =        {McNally, Louise},
+  booktitle =     {Semantics: An International Handbook of Natural
+                   Language Meaning. Volume 2},
+  editor =        {von Heusinger, Klaus and Maienborn, Claudia and
+                   Portner, Paul},
+  number =        {33.2},
+  pages =         {1829--1848},
+  publisher =     {de Gruyter Monton},
+  series =        {Handbooks of Linguistics and Communication Science},
+  title =         {Existential Sentences},
+  year =          {2011},
+}
+
+@article{moss_ls:2010,
+  author =        {Moss, Lawrence S.},
+  journal =       {Journal of Logic and Computation},
+  number =        {4},
+  pages =         {947--967},
+  title =         {Syllogistic Logics with Verbs},
+  volume =        {20},
+  year =          {2010},
+    doi = {10.1093/logcom/exn086},
+}
+
+@incollection{moss_ls:2010a,
+  address =       {Berlin},
+  author =        {Moss, Lawrence S.},
+  booktitle =     {Fields of Logic and Computation. Essays Dedicated to
+                   Yuri Gurevich on the Occasion of His 70th Birthday},
+  editor =        {Blass, Andreas and Dersowitz, Nachum and
+                   Reisig, Wolfgang},
+  pages =         {538--564},
+  publisher =     {Springer Verlag},
+  title =         {Logics for Two Fragments beyond the Syllogistic
+                   Boundary},
+  year =          {2010},
+}
+
+@incollection{moss_ls:2010b,
+  address =       {Berlin},
+  author =        {Moss, Lawrence S.},
+  booktitle =     {Logic, Language and Meaning. 17th Amsterdam
+                   Colloquium, Amsterdam, The Netherlands, December
+                   16-18, 2009. Revised Selected Papers},
+  pages =         {84--93},
+  publisher =     {Springer Verlag},
+  title =         {Natural Logic and Semantics},
+  year =          {2010},
+}
+
+@Article{moss_ls:2011,
+  author  = {Moss, Lawrence S.},
+  journal = {Journal of Logic, Language, and Information},
+  title   = {Syllogistic Logics With Comparative Adjectives},
+  year    = {2011},
+  number  = {3},
+  pages   = {397--417},
+  volume  = {20},
+  doi     = {10.1007/s10849-011-9137-x},
+}
+
+@incollection{moss_ls:2015,
+  address =       {Oxford},
+  author =        {Moss, Lawrence S.},
+  booktitle =     {The Handbook of Contemporary Semantic Theory},
+  edition =       {2},
+  editor =        {Lappin, Shalom and Fox, Chris},
+  note =          {first edition: \citet{lappin:1996}},
+  pages =         {561--592},
+  publisher =     {John Wiley \& Sons, Inc.},
+  title =         {Natural Logic},
+  year =          {2015},
+}
+
+@incollection{moss_ls:2016,
+  address =       {Cham},
+  author =        {Moss, Lawrence S.},
+  booktitle =     {J. Michael Dunn on Information Based Logics},
+  editor =        {Bimb{\'o}, Katalin},
+  number =        {8},
+  pages =         {391--416},
+  publisher =     {Springer International Publishing},
+  series =        {Outstanding Contributions to Logic},
+  title =         {Syllogistic Logic with Cardinality Comparisons},
+  year =          {2016},
+}
+
+@article{moss_ls-topal:2020,
+  author =        {Moss, Lawrence S. and Topal, Sel{\c{c}}uk},
+  journal =       {The Review of Symbolic Logic},
+  number =        {1},
+  pages =         {1--22},
+  title =         {Syllogistic Logic with Cardinality Comparisons, On
+                   Infinite Sets},
+  volume =        {13},
+  year =          {2020},
+    doi = {10.1017/S1755020318000126},
+}
+
+@phdthesis{pavlovic:2017,
+  address =       {Budapest},
+  author =        {Pavlovi{\'c}, Edi},
+  school =        {Central European University},
+  type =          {PhD},
+  title =         {The Quantified Argument Calculus: An Inquiry into Its
+                   Logical Properties and Applications},
+  year =          {2017},
+}
+
+@Article{pavlovic-gratzl:2019,
+  author  = {Pavlovi{\'c}, Edi and Gratz, Norbert},
+  journal = {The Review of Symbolic Logic},
+  title   = {Proof-Theoretic Analysis of the Quantified Argument Calculus},
+  year    = {2019},
+  number  = {4},
+  pages   = {607--636},
+  volume  = {12},
+  doi     = {10.1017/s1755020318000114},
+}
+
+@Article{pratthartmann-moss:2009,
+  author  = {Pratt-Hartmann, Ian and Moss, Lawrence S.},
+  journal = {The Review of Symbolic Logic},
+  title   = {Logics for the Relational Syllogistic},
+  year    = {2009},
+  number  = {4},
+  pages   = {647--683},
+  volume  = {2},
+  doi     = {10.1017/s1755020309990086},
+}
+
+@Article{raab_j:2018,
+  author  = {Raab, Jonas},
+  journal = {History and Philosophy of Logic},
+  title   = {Aristotle, Logic, and QUARC},
+  year    = {2018},
+  number  = {4},
+  pages   = {305--340},
+  volume  = {39},
+  doi     = {10.1080/01445340.2018.1467198},
+}
+
+@book{sommers_f:1982,
+  address =       {Oxford},
+  author =        {Sommers, Fred},
+  publisher =     {Oxford University Press},
+  title =         {The Logic of Natural Language},
+  year =          {1982},
+}
+
+@Article{strawson_pf:1950,
+  author  = {Strawson, Peter Frederick},
+  journal = {Mind},
+  title   = {On Referring},
+  year    = {1950},
+  note    = {reprinted, with some added footnotes, in \citet[1--20]{strawson_pf:2004}},
+  number  = {235},
+  pages   = {320--344},
+  volume  = {59},
+  doi     = {10.2307/2266359},
+}
+
+@book{strawson_pf:1952,
+  address =       {London},
+  author =        {Strawson, Peter Frederick},
+  publisher =     {Methuen \& Co.},
+  title =         {Introduction to Logical Theory},
+  year =          {1952},
+}
+
+@book{lappin-fox:2015,
+  address =       {Oxford},
+  booktitle =     {The Handbook of Contemporary Semantic Theory},
+  edition =       {2},
+  editor =        {Lappin, Shalom and Fox, Chris},
+  note =          {first edition: \citet{lappin:1996}},
+  publisher =     {John Wiley \& Sons, Inc.},
+  title =         {The Handbook of Contemporary Semantic Theory},
+  year =          {2015},
+}
+
+@book{lemmon:1965,
+  address =       {London},
+  author =        {Lemmon, Edward John},
+  publisher =     {Thomas Nelson and Sons Ltd.},
+  title =         {Beginning Logic},
+  year =          {1965},
+}
+
+@book{flew_an:1956,
+  address =       {London},
+  booktitle =     {Essays in Conceptual Analysis},
+  editor =        {Flew, Antony Garrard Newton},
+  publisher =     {MacMillan Publishing Co.},
+  title =         {Essays in Conceptual Analysis},
+  year =          {1956},
+}
+
+@book{caton_ce:1963,
+  address =       {Urbana, Illinois},
+  booktitle =     {Philosophy and Ordinary Language},
+  editor =        {Caton, Charles E.},
+  publisher =     {University of Illinois Press},
+  title =         {Philosophy and Ordinary Language},
+  year =          {1963},
+}
+
+@book{klemke_ed:1970,
+  address =       {Urbana, Illinois},
+  booktitle =     {Essays on Russell},
+  editor =        {Klemke, Elmer Daniel},
+  publisher =     {University of Illinois Press},
+  title =         {Essays on Russell},
+  year =          {1970},
+}
+
+@book{strawson_pf:1971,
+  address =       {London},
+  author =        {Strawson, Peter Frederick},
+  booktitle =     {Logico-Linguistic Papers},
+  note =          {reprinted as \citet{strawson_pf:2004}},
+  publisher =     {Methuen \& Co.},
+  title =         {Logico-Linguistic Papers},
+  year =          {1971},
+}
+
+@book{moore_aw:1993,
+  address =       {Oxford},
+  booktitle =     {Meaning and Reference},
+  editor =        {Moore, Adrian W.},
+  publisher =     {Oxford University Press},
+  series =        {Oxford Readings in Philosophy},
+  title =         {Meaning and Reference},
+  year =          {1993},
+}
+
+@book{hendricks_vf-etal:2004,
+  address =       {Berlin},
+  booktitle =     {First-Order Logic Revisited},
+  editor =        {Hendricks, Vincent F. and Neuhaus, Fabian and
+                   Pedersen, Stig Andur and Scheffler, Uwe and
+                   Wansing, Heinrich},
+  number =        {12},
+  publisher =     {Logos Verlag},
+  series =        {Logische Philosophie},
+  title =         {First-Order Logic Revisited},
+  year =          {2004},
+}
+
+@book{vonheusinger-etal:2011,
+  address =       {Berlin},
+  booktitle =     {Semantics: An International Handbook of Natural
+                   Language Meaning. Volume 2},
+  editor =        {von Heusinger, Klaus and Maienborn, Claudia and
+                   Portner, Paul},
+  number =        {33.2},
+  publisher =     {de Gruyter Monton},
+  series =        {Handbooks of Linguistics and Communication Science},
+  title =         {Semantics: An International Handbook of Natural
+                   Language Meaning. Volume 2},
+  year =          {2011},
+}
+
+@book{blass-etal:2010,
+  address =       {Berlin},
+  booktitle =     {Fields of Logic and Computation. Essays Dedicated to
+                   Yuri Gurevich on the Occasion of His 70th Birthday},
+  editor =        {Blass, Andreas and Dersowitz, Nachum and
+                   Reisig, Wolfgang},
+  publisher =     {Springer Verlag},
+  title =         {Fields of Logic and Computation. Essays Dedicated to
+                   Yuri Gurevich on the Occasion of His 70th Birthday},
+  year =          {2010},
+}
+
+@book{aloni-etal:2010,
+  address =       {Berlin},
+  author =        {Aloni, Maria and Bastiaanse, Harald and
+                   de Jager, Tikitu and Schulz, Katrin},
+  booktitle =     {Logic, Language and Meaning. 17th Amsterdam
+                   Colloquium, Amsterdam, The Netherlands, December
+                   16-18, 2009. Revised Selected Papers},
+  publisher =     {Springer Verlag},
+  title =         {Logic, Language and Meaning. 17th Amsterdam
+                   Colloquium, Amsterdam, The Netherlands, December
+                   16-18, 2009. Revised Selected Papers},
+  year =          {2010},
+}
+
+@book{bimbo:2016,
+  address =       {Cham},
+  booktitle =     {J. Michael Dunn on Information Based Logics},
+  editor =        {Bimb{\'o}, Katalin},
+  number =        {8},
+  publisher =     {Springer International Publishing},
+  series =        {Outstanding Contributions to Logic},
+  title =         {J. Michael Dunn on Information Based Logics},
+  year =          {2016},
+}
+
+@book{chakraborty_mk-etal:2008,
+  address =       {London},
+  booktitle =     {Logic, Navya-Ny{\=a}ya \& Applications. Hommage to
+                   Bimal Krishna Matilal},
+  editor =        {Chakraborty, Mihir K. and Löwe, Benedikt and
+                   Nath Mitra, Madhabendra and Surakkai, Sundar},
+  publisher =     {College Publications},
+  series =        {Studies in Logic},
+  title =         {Logic, Navya-Ny{\=a}ya \& Applications. Hommage to
+                   Bimal Krishna Matilal},
+  year =          {2008},
+}
+
+@Comment{jabref-meta: databaseType:bibtex;}

--- a/selfcites/sample_completed.bib
+++ b/selfcites/sample_completed.bib
@@ -1,0 +1,565 @@
+@book{aloni-etal:2010,
+ address = {Berlin},
+ author = {Aloni, Maria and Bastiaanse, Harald and
+de Jager, Tikitu and Schulz, Katrin},
+ booktitle = {Logic, Language and Meaning. 17th Amsterdam
+Colloquium, Amsterdam, The Netherlands, December
+16-18, 2009. Revised Selected Papers},
+ publisher = {Springer Verlag},
+ title = {Logic, Language and Meaning. 17th Amsterdam
+Colloquium, Amsterdam, The Netherlands, December
+16-18, 2009. Revised Selected Papers},
+ year = {2010}
+}
+
+@unpublished{benyami-pavlovic:unpub,
+ author = {Ben-Yami, Hanoch and Pavlovic, Edi},
+ note = {Unpublished manuscript},
+ title = {The Completeness of the Quantified Argument Calculus
+on the Truth-Valuational Approach},
+ year = {2020}
+}
+
+@book{benyami:2004,
+ address = {Aldershot, Hampshire},
+ author = {Ben-Yami, Hanoch},
+ publisher = {Ashgate Publishing Limited},
+ title = {Logic \& Natural Language. On Plural Reference and
+Its Semantic and Logical Significance},
+ year = {2004}
+}
+
+@article{benyami:2009a,
+ author = {Ben-Yami, Hanoch},
+ journal = {Logique et Analyse},
+ number = {208},
+ pages = {309--326},
+ title = {Generalized Quantifiers, and Beyond},
+ volume = {52},
+ year = {2009}
+}
+
+@article{benyami:2014b,
+ author = {Ben-Yami, Hanoch},
+ doi = {10.1017/s1755020313000373},
+ journal = {The Review of Symbolic Logic},
+ number = {1},
+ pages = {120--146},
+ title = {The Quantified Argument Calculus},
+ volume = {7},
+ year = {2014}
+}
+
+@article{benyami:forthcoming,
+ author = {Ben-Yami, Hanoch},
+ journal = {Synthese},
+ title = {The Barcan Formulas and Necessary Existence: the View
+from Quarc},
+ year = {forthcoming}
+}
+
+@book{bimbo:2016,
+ address = {Cham},
+ booktitle = {J. Michael Dunn on Information Based Logics},
+ editor = {Bimb{\'o}, Katalin},
+ number = {8},
+ publisher = {Springer International Publishing},
+ series = {Outstanding Contributions to Logic},
+ title = {J. Michael Dunn on Information Based Logics},
+ year = {2016}
+}
+
+@book{blass-etal:2010,
+ address = {Berlin},
+ booktitle = {Fields of Logic and Computation. Essays Dedicated to
+Yuri Gurevich on the Occasion of His 70th Birthday},
+ editor = {Blass, Andreas and Dersowitz, Nachum and
+Reisig, Wolfgang},
+ publisher = {Springer Verlag},
+ title = {Fields of Logic and Computation. Essays Dedicated to
+Yuri Gurevich on the Occasion of His 70th Birthday},
+ year = {2010}
+}
+
+@book{caton_ce:1963,
+ address = {Urbana, Illinois},
+ booktitle = {Philosophy and Ordinary Language},
+ editor = {Caton, Charles E.},
+ publisher = {University of Illinois Press},
+ title = {Philosophy and Ordinary Language},
+ year = {1963}
+}
+
+@book{chakraborty_mk-etal:2008,
+ address = {London},
+ booktitle = {Logic, Navya-Ny{\=a}ya \& Applications. Hommage to
+Bimal Krishna Matilal},
+ editor = {Chakraborty, Mihir K. and Löwe, Benedikt and
+Nath Mitra, Madhabendra and Surakkai, Sundar},
+ publisher = {College Publications},
+ series = {Studies in Logic},
+ title = {Logic, Navya-Ny{\=a}ya \& Applications. Hommage to
+Bimal Krishna Matilal},
+ year = {2008}
+}
+
+@article{cobreros-etal:2013a,
+ author = {Cobreros, Pablo and {\'E}gr{\'e}, Paul and Ripley, David and van Rooij, Robert},
+ doi = {10.1093/mind/fzt110},
+ journal = {Mind},
+ number = {488},
+ pages = {841--866},
+ title = {Reaching Transparent Truth},
+ volume = {122},
+ year = {2013}
+}
+
+@book{fitch_fb:1952,
+ address = {New York},
+ author = {Fitch, Frederic B.},
+ publisher = {Ronald Press Co.},
+ title = {Symbolic Logic: An Introduction},
+ year = {1952}
+}
+
+@book{flew_an:1956,
+ address = {London},
+ booktitle = {Essays in Conceptual Analysis},
+ editor = {Flew, Antony Garrard Newton},
+ publisher = {MacMillan Publishing Co.},
+ title = {Essays in Conceptual Analysis},
+ year = {1956}
+}
+
+@article{francez_i:2009,
+ author = {Francez, Itamar},
+ doi = {10.1007/s10988-009-9055-4},
+ journal = {Linguistics and Philosophy},
+ number = {1},
+ pages = {1--50},
+ title = {Existentials, Predication, and Modification},
+ volume = {32},
+ year = {2009}
+}
+
+@book{frege:1879,
+ address = {Halle a.S.},
+ author = {Frege, Gottlob},
+ publisher = {Louis Nebert},
+ title = {Begriffsschrift, eine der arithmetischen
+nachgebildete Formelsprache des reinen Denkens},
+ year = {1879}
+}
+
+@book{geach_pt:1962,
+ address = {Ithaca, New York},
+ author = {Geach, Peter Thomas},
+ note = {third edition:~\citet{geach_pt:1980}},
+ publisher = {Cornell University Press},
+ title = {Reference and Generality, an examination of some
+medieval and modern theories},
+ year = {1962}
+}
+
+@book{geach_pt:1980,
+ address = {Ithaca, New York},
+ author = {Geach, Peter Thomas},
+ edition = {3},
+ note = {first edition: \citet{geach_pt:1962}},
+ publisher = {Cornell University Press},
+ title = {Reference and Generality, an examination of some
+medieval and modern theories},
+ year = {1980}
+}
+
+@book{hallden:1949,
+ address = {Uppsala},
+ author = {Halld{\'e}n, S{\"o}ren},
+ publisher = {Uppsala Universitet},
+ title = {The Logic of Nonsense},
+ year = {1949}
+}
+
+@book{hendricks_vf-etal:2004,
+ address = {Berlin},
+ booktitle = {First-Order Logic Revisited},
+ editor = {Hendricks, Vincent F. and Neuhaus, Fabian and
+Pedersen, Stig Andur and Scheffler, Uwe and
+Wansing, Heinrich},
+ number = {12},
+ publisher = {Logos Verlag},
+ series = {Logische Philosophie},
+ title = {First-Order Logic Revisited},
+ year = {2004}
+}
+
+@article{henkin:1949,
+ author = {Henkin, Leon},
+ doi = {10.2307/2267044},
+ journal = {The Journal of Symbolic Logic},
+ number = {3},
+ pages = {159--166},
+ title = {The Completeness of the First-Order Functional Calculus},
+ volume = {14},
+ year = {1949}
+}
+
+@article{jaskowski:1934,
+ author = {Ja{\'s}kowski, Stanis{\l}aw},
+ journal = {Studia Logica (Poznan Panstwowe Wydawnictowo
+Naukowe)},
+ note = {reprinted in \citet[232--258]{mccall_s:1967}, with
+considerable change in notation},
+ pages = {5--32},
+ title = {On the Rules of Suppositions in Formal Logic},
+ volume = {1},
+ year = {1934}
+}
+
+@book{klemke_ed:1970,
+ address = {Urbana, Illinois},
+ booktitle = {Essays on Russell},
+ editor = {Klemke, Elmer Daniel},
+ publisher = {University of Illinois Press},
+ title = {Essays on Russell},
+ year = {1970}
+}
+
+@incollection{lanzet_r-benyami:2004,
+ address = {Berlin},
+ author = {Lanzet, Ran and Ben-Yami, Hanoch},
+ booktitle = {First-Order Logic Revisited},
+ editor = {Hendricks, Vincent F. and Neuhaus, Fabian and
+Pedersen, Stig Andur and Scheffler, Uwe and
+Wansing, Heinrich},
+ number = {12},
+ pages = {173--224},
+ publisher = {Logos Verlag},
+ series = {Logische Philosophie},
+ title = {Logical Inquiries into a New Formal System with
+Plural Reference},
+ year = {2004}
+}
+
+@article{lanzet_r:2017,
+ author = {Lanzet, Ran},
+ doi = {10.1017/s1755020317000053},
+ journal = {Linguistics and Philosophy},
+ num_sort = {73107},
+ number = {2},
+ pages = {207--234},
+ title = {A Three-Valued Quantified Argument Calculus: Domain-Free Model-Theory, Completeness, and Embedding of FOL},
+ topic = {pragmatics;speech-acts;ok},
+ volume = {30},
+ year = {2017}
+}
+
+@book{lappin-fox:2015,
+ address = {Oxford},
+ booktitle = {The Handbook of Contemporary Semantic Theory},
+ edition = {2},
+ editor = {Lappin, Shalom and Fox, Chris},
+ note = {first edition: \citet{lappin:1996}},
+ publisher = {John Wiley \& Sons, Inc.},
+ title = {The Handbook of Contemporary Semantic Theory},
+ year = {2015}
+}
+
+@book{lappin:1996,
+ address = {Oxford},
+ booktitle = {The Handbook of Contemporary Semantic Theory},
+ editor = {Lappin, Shalom},
+ publisher = {Basil Blackwell Publishers},
+ title = {The Handbook of Contemporary Semantic Theory},
+ year = {1996}
+}
+
+@book{lemmon:1965,
+ address = {London},
+ author = {Lemmon, Edward John},
+ publisher = {Thomas Nelson and Sons Ltd.},
+ title = {Beginning Logic},
+ year = {1965}
+}
+
+@book{lemmon:1978,
+ address = {Indianapolis, Indiana},
+ author = {Lemmon, Edward John},
+ note = {first edition: \citet{lemmon:1965}},
+ publisher = {Hackett Publishing Co.},
+ title = {Beginning Logic},
+ year = {1978}
+}
+
+@article{lewis_ha:1985a,
+ author = {Lewis, Harry A.},
+ doi = {10.2307/2214953},
+ journal = {No{\^u}s},
+ number = {3},
+ pages = {447--451},
+ title = {Substitutional Quantification and Nonstandard Quantifiers},
+ volume = {19},
+ year = {1985}
+}
+
+@book{mccall_s:1967,
+ address = {Oxford},
+ booktitle = {Polish Logic 1920--1939},
+ editor = {McCall, Storrs},
+ publisher = {Oxford University Press},
+ title = {Polish Logic 1920--1939},
+ year = {1967}
+}
+
+@incollection{mcnally_l:2011,
+ address = {Berlin},
+ author = {McNally, Louise},
+ booktitle = {Semantics: An International Handbook of Natural
+Language Meaning. Volume 2},
+ editor = {von Heusinger, Klaus and Maienborn, Claudia and
+Portner, Paul},
+ number = {33.2},
+ pages = {1829--1848},
+ publisher = {de Gruyter Monton},
+ series = {Handbooks of Linguistics and Communication Science},
+ title = {Existential Sentences},
+ year = {2011}
+}
+
+@book{moore_aw:1993,
+ address = {Oxford},
+ booktitle = {Meaning and Reference},
+ editor = {Moore, Adrian W.},
+ publisher = {Oxford University Press},
+ series = {Oxford Readings in Philosophy},
+ title = {Meaning and Reference},
+ year = {1993}
+}
+
+@article{moss_ls-topal:2020,
+ author = {Moss, Lawrence S. and Topal, Sel{\c{c}}uk},
+ doi = {10.1017/S1755020318000126},
+ journal = {The Review of Symbolic Logic},
+ number = {1},
+ pages = {1--22},
+ title = {Syllogistic Logic with Cardinality Comparisons, On
+Infinite Sets},
+ volume = {13},
+ year = {2020}
+}
+
+@article{moss_ls:2010,
+ author = {Moss, Lawrence S.},
+ doi = {10.1093/logcom/exn086},
+ journal = {Journal of Logic and Computation},
+ number = {4},
+ pages = {947--967},
+ title = {Syllogistic Logics with Verbs},
+ volume = {20},
+ year = {2010}
+}
+
+@incollection{moss_ls:2010a,
+ address = {Berlin},
+ author = {Moss, Lawrence S.},
+ booktitle = {Fields of Logic and Computation. Essays Dedicated to
+Yuri Gurevich on the Occasion of His 70th Birthday},
+ editor = {Blass, Andreas and Dersowitz, Nachum and
+Reisig, Wolfgang},
+ pages = {538--564},
+ publisher = {Springer Verlag},
+ title = {Logics for Two Fragments beyond the Syllogistic
+Boundary},
+ year = {2010}
+}
+
+@incollection{moss_ls:2010b,
+ address = {Berlin},
+ author = {Moss, Lawrence S.},
+ booktitle = {Logic, Language and Meaning. 17th Amsterdam
+Colloquium, Amsterdam, The Netherlands, December
+16-18, 2009. Revised Selected Papers},
+ pages = {84--93},
+ publisher = {Springer Verlag},
+ title = {Natural Logic and Semantics},
+ year = {2010}
+}
+
+@article{moss_ls:2011,
+ author = {Moss, Lawrence S.},
+ doi = {10.1007/s10849-011-9137-x},
+ journal = {Journal of Logic, Language, and Information},
+ number = {3},
+ pages = {397--417},
+ title = {Syllogistic Logics With Comparative Adjectives},
+ volume = {20},
+ year = {2011}
+}
+
+@incollection{moss_ls:2015,
+ address = {Oxford},
+ author = {Moss, Lawrence S.},
+ booktitle = {The Handbook of Contemporary Semantic Theory},
+ edition = {2},
+ editor = {Lappin, Shalom and Fox, Chris},
+ note = {first edition: \citet{lappin:1996}},
+ pages = {561--592},
+ publisher = {John Wiley \& Sons, Inc.},
+ title = {Natural Logic},
+ year = {2015}
+}
+
+@incollection{moss_ls:2016,
+ address = {Cham},
+ author = {Moss, Lawrence S.},
+ booktitle = {J. Michael Dunn on Information Based Logics},
+ editor = {Bimb{\'o}, Katalin},
+ number = {8},
+ pages = {391--416},
+ publisher = {Springer International Publishing},
+ series = {Outstanding Contributions to Logic},
+ title = {Syllogistic Logic with Cardinality Comparisons},
+ year = {2016}
+}
+
+@article{pavlovic-gratzl:2019,
+ author = {Pavlovi{\'c}, Edi and Gratz, Norbert},
+ doi = {10.1017/s1755020318000114},
+ journal = {The Review of Symbolic Logic},
+ number = {4},
+ pages = {607--636},
+ title = {Proof-Theoretic Analysis of the Quantified Argument Calculus},
+ volume = {12},
+ year = {2019}
+}
+
+@phdthesis{pavlovic:2017,
+ address = {Budapest},
+ author = {Pavlovi{\'c}, Edi},
+ school = {Central European University},
+ title = {The Quantified Argument Calculus: An Inquiry into Its
+Logical Properties and Applications},
+ type = {PhD},
+ year = {2017}
+}
+
+@article{pratthartmann-moss:2009,
+ author = {Pratt-Hartmann, Ian and Moss, Lawrence S.},
+ doi = {10.1017/s1755020309990086},
+ journal = {The Review of Symbolic Logic},
+ number = {4},
+ pages = {647--683},
+ title = {Logics for the Relational Syllogistic},
+ volume = {2},
+ year = {2009}
+}
+
+@article{raab_j:2018,
+ author = {Raab, Jonas},
+ doi = {10.1080/01445340.2018.1467198},
+ journal = {History and Philosophy of Logic},
+ number = {4},
+ pages = {305--340},
+ title = {Aristotle, Logic, and QUARC},
+ volume = {39},
+ year = {2018}
+}
+
+@book{sommers_f:1982,
+ address = {Oxford},
+ author = {Sommers, Fred},
+ publisher = {Oxford University Press},
+ title = {The Logic of Natural Language},
+ year = {1982}
+}
+
+@article{strawson_pf:1950,
+ author = {Strawson, Peter Frederick},
+ doi = {10.2307/2266359},
+ journal = {Mind},
+ note = {reprinted, with some added footnotes, in \citet[1--20]{strawson_pf:2004}},
+ number = {235},
+ pages = {320--344},
+ title = {On Referring},
+ volume = {59},
+ year = {1950}
+}
+
+@book{strawson_pf:1952,
+ address = {London},
+ author = {Strawson, Peter Frederick},
+ publisher = {Methuen \& Co.},
+ title = {Introduction to Logical Theory},
+ year = {1952}
+}
+
+@book{strawson_pf:1971,
+ address = {London},
+ author = {Strawson, Peter Frederick},
+ booktitle = {Logico-Linguistic Papers},
+ note = {reprinted as \citet{strawson_pf:2004}},
+ publisher = {Methuen \& Co.},
+ title = {Logico-Linguistic Papers},
+ year = {1971}
+}
+
+@book{strawson_pf:2004,
+ address = {Aldershot, Hampshire},
+ booktitle = {Logico-Linguistic Papers},
+ edition = {2},
+ editor = {Strawson, Peter Frederick},
+ publisher = {Ashgate Publishing Limited},
+ title = {Logico-Linguistic Papers},
+ year = {2004}
+}
+
+@book{vanbenthem:1986,
+ address = {Dordrecht},
+ author = {van Benthem, Johan},
+ booktitle = {Essays in Logical Semantics},
+ number = {29},
+ publisher = {D.~Reidel Publishing Co.},
+ series = {Studies in Linguistics and Philosophy},
+ title = {Essays in Logical Semantics},
+ year = {1986}
+}
+
+@book{vanbenthem:1991,
+ address = {Amsterdam},
+ author = {van Benthem, Johan},
+ number = {130},
+ publisher = {North-Holland Publishing Co.},
+ series = {Studies in Logic and the Foundations of Mathematics},
+ title = {Language in Action: Categories, Lambdas, and Dynamic
+Logic},
+ year = {1991}
+}
+
+@incollection{vanbenthem:2008,
+ address = {London},
+ author = {van Benthem, Johan},
+ booktitle = {Logic, Navya-Ny{\=a}ya \& Applications. Hommage to
+Bimal Krishna Matilal},
+ editor = {Chakraborty, Mihir K. and Löwe, Benedikt and
+Nath Mitra, Madhabendra and Surakkai, Sundar},
+ pages = {21--42},
+ publisher = {College Publications},
+ series = {Studies in Logic},
+ title = {Natural Logic: A View from the 1980s},
+ year = {2008}
+}
+
+@book{vonheusinger-etal:2011,
+ address = {Berlin},
+ booktitle = {Semantics: An International Handbook of Natural
+Language Meaning. Volume 2},
+ editor = {von Heusinger, Klaus and Maienborn, Claudia and
+Portner, Paul},
+ number = {33.2},
+ publisher = {de Gruyter Monton},
+ series = {Handbooks of Linguistics and Communication Science},
+ title = {Semantics: An International Handbook of Natural
+Language Meaning. Volume 2},
+ year = {2011}
+}
+

--- a/selfcites/selfcites.py
+++ b/selfcites/selfcites.py
@@ -1,5 +1,5 @@
 #! usr/bin/python
-# Script copyright Thomas Hodgson
+# Script copyright Thomas Hodgson 2021
 # MIT License
 
 """
@@ -19,7 +19,7 @@ biblatex file with missing entries added from the argument to --source. The new 
 of the optional argument --suffix added to the name of the original file.
 The default value of --suffix is '_extended'.
 
-Dependencies:
+Requires python 3. Dependencies:
 
 - argparse
 - os
@@ -53,7 +53,8 @@ parser.add_argument(
 )
 args = parser.parse_args()
 
-if args.source
+# if a --source option is provided, we need bibtexparser
+if args.source:
     import bibtexparser
     from bibtexparser.bwriter import BibTexWriter
     from bibtexparser.bibdatabase import BibDatabase

--- a/selfcites/source.bib
+++ b/selfcites/source.bib
@@ -1,0 +1,569 @@
+% Encoding: UTF-8
+
+
+@book{vanbenthem:1986,
+  address =       {Dordrecht},
+  author =        {van Benthem, Johan},
+  booktitle =     {Essays in Logical Semantics},
+  number =        {29},
+  publisher =     {D.~Reidel Publishing Co.},
+  series =        {Studies in Linguistics and Philosophy},
+  title =         {Essays in Logical Semantics},
+  year =          {1986},
+}
+
+@book{vanbenthem:1991,
+  address =       {Amsterdam},
+  author =        {van Benthem, Johan},
+  number =        {130},
+  publisher =     {North-Holland Publishing Co.},
+  series =        {Studies in Logic and the Foundations of Mathematics},
+  title =         {Language in Action: Categories, Lambdas, and Dynamic
+                   Logic},
+  year =          {1991},
+}
+
+@incollection{vanbenthem:2008,
+  address =       {London},
+  author =        {van Benthem, Johan},
+  booktitle =     {Logic, Navya-Ny{\=a}ya \& Applications. Hommage to
+                   Bimal Krishna Matilal},
+  editor =        {Chakraborty, Mihir K. and Löwe, Benedikt and
+                   Nath Mitra, Madhabendra and Surakkai, Sundar},
+  pages =         {21--42},
+  publisher =     {College Publications},
+  series =        {Studies in Logic},
+  title =         {Natural Logic: A View from the 1980s},
+  year =          {2008},
+}
+
+@book{benyami:2004,
+  address =       {Aldershot, Hampshire},
+  author =        {Ben-Yami, Hanoch},
+  publisher =     {Ashgate Publishing Limited},
+  title =         {Logic \& Natural Language. On Plural Reference and
+                   Its Semantic and Logical Significance},
+  year =          {2004},
+}
+
+@article{benyami:2009a,
+  author =        {Ben-Yami, Hanoch},
+  journal =       {Logique et Analyse},
+  number =        {208},
+  pages =         {309--326},
+  title =         {Generalized Quantifiers, and Beyond},
+  volume =        {52},
+  year =          {2009},
+}
+
+@Article{benyami:2014b,
+  author  = {Ben-Yami, Hanoch},
+  journal = {The Review of Symbolic Logic},
+  title   = {The Quantified Argument Calculus},
+  year    = {2014},
+  number  = {1},
+  pages   = {120--146},
+  volume  = {7},
+  doi     = {10.1017/s1755020313000373},
+}
+
+@article{benyami:forthcoming,
+  author =        {Ben-Yami, Hanoch},
+  journal =       {Synthese},
+  title =         {The Barcan Formulas and Necessary Existence: the View
+                   from Quarc},
+  year =          {forthcoming},
+}
+
+@unpublished{benyami-pavlovic:unpub,
+  author =        {Ben-Yami, Hanoch and Pavlovic, Edi},
+  note =          {Unpublished manuscript},
+  title =         {The Completeness of the Quantified Argument Calculus
+                   on the Truth-Valuational Approach},
+  year =          {2020},
+}
+
+@Article{cobreros-etal:2013a,
+  author  = {Cobreros, Pablo and {\'E}gr{\'e}, Paul and Ripley, David and van Rooij, Robert},
+  journal = {Mind},
+  title   = {Reaching Transparent Truth},
+  year    = {2013},
+  number  = {488},
+  pages   = {841--866},
+  volume  = {122},
+  doi     = {10.1093/mind/fzt110},
+}
+
+@book{fitch_fb:1952,
+  address =       {New York},
+  author =        {Fitch, Frederic B.},
+  publisher =     {Ronald Press Co.},
+  title =         {Symbolic Logic: An Introduction},
+  year =          {1952},
+}
+
+@Article{francez_i:2009,
+  author  = {Francez, Itamar},
+  journal = {Linguistics and Philosophy},
+  title   = {Existentials, Predication, and Modification},
+  year    = {2009},
+  number  = {1},
+  pages   = {1--50},
+  volume  = {32},
+  doi     = {10.1007/s10988-009-9055-4},
+}
+
+@book{frege:1879,
+  address =       {Halle a.S.},
+  author =        {Frege, Gottlob},
+  publisher =     {Louis Nebert},
+  title =         {Begriffsschrift, eine der arithmetischen
+                   nachgebildete Formelsprache des reinen Denkens},
+  year =          {1879},
+}
+
+@book{geach_pt:1962,
+  address =       {Ithaca, New York},
+  author =        {Geach, Peter Thomas},
+  note =          {third edition:~\citet{geach_pt:1980}},
+  publisher =     {Cornell University Press},
+  title =         {Reference and Generality, an examination of some
+                   medieval and modern theories},
+  year =          {1962},
+}
+
+@book{hallden:1949,
+  address =       {Uppsala},
+  author =        {Halld{\'e}n, S{\"o}ren},
+  publisher =     {Uppsala Universitet},
+  title =         {The Logic of Nonsense},
+  year =          {1949},
+}
+
+@Article{henkin:1949,
+  author  = {Henkin, Leon},
+  journal = {The Journal of Symbolic Logic},
+  title   = {The Completeness of the First-Order Functional Calculus},
+  year    = {1949},
+  number  = {3},
+  pages   = {159--166},
+  volume  = {14},
+  doi     = {10.2307/2267044},
+}
+
+@article{jaskowski:1934,
+  author =        {Ja{\'s}kowski, Stanis{\l}aw},
+  journal =       {Studia Logica (Poznan Panstwowe Wydawnictowo
+                   Naukowe)},
+  note =          {reprinted in \citet[232--258]{mccall_s:1967}, with
+                   considerable change in notation},
+  pages =         {5--32},
+  title =         {On the Rules of Suppositions in Formal Logic},
+  volume =        {1},
+  year =          {1934},
+}
+
+@incollection{lanzet_r-benyami:2004,
+  address =       {Berlin},
+  author =        {Lanzet, Ran and Ben-Yami, Hanoch},
+  booktitle =     {First-Order Logic Revisited},
+  editor =        {Hendricks, Vincent F. and Neuhaus, Fabian and
+                   Pedersen, Stig Andur and Scheffler, Uwe and
+                   Wansing, Heinrich},
+  number =        {12},
+  pages =         {173--224},
+  publisher =     {Logos Verlag},
+  series =        {Logische Philosophie},
+  title =         {Logical Inquiries into a New Formal System with
+                   Plural Reference},
+  year =          {2004},
+}
+
+@Article{lanzet_r:2017,
+  author   = {Lanzet, Ran},
+  journal  = {Linguistics and Philosophy},
+  title    = {A Three-Valued Quantified Argument Calculus: Domain-Free Model-Theory, Completeness, and Embedding of FOL},
+  year     = {2017},
+  number   = {2},
+  pages    = {207--234},
+  volume   = {30},
+  doi      = {10.1017/s1755020317000053},
+  num_sort = {73107},
+  topic    = {pragmatics;speech-acts;ok},
+}
+
+@book{lemmon:1978,
+  address =       {Indianapolis, Indiana},
+  author =        {Lemmon, Edward John},
+  note =          {first edition: \citet{lemmon:1965}},
+  publisher =     {Hackett Publishing Co.},
+  title =         {Beginning Logic},
+  year =          {1978},
+}
+
+@Article{lewis_ha:1985a,
+  author  = {Lewis, Harry A.},
+  journal = {No{\^u}s},
+  title   = {Substitutional Quantification and Nonstandard Quantifiers},
+  year    = {1985},
+  number  = {3},
+  pages   = {447--451},
+  volume  = {19},
+  doi     = {10.2307/2214953},
+}
+
+@incollection{mcnally_l:2011,
+  address =       {Berlin},
+  author =        {McNally, Louise},
+  booktitle =     {Semantics: An International Handbook of Natural
+                   Language Meaning. Volume 2},
+  editor =        {von Heusinger, Klaus and Maienborn, Claudia and
+                   Portner, Paul},
+  number =        {33.2},
+  pages =         {1829--1848},
+  publisher =     {de Gruyter Monton},
+  series =        {Handbooks of Linguistics and Communication Science},
+  title =         {Existential Sentences},
+  year =          {2011},
+}
+
+@article{moss_ls:2010,
+  author =        {Moss, Lawrence S.},
+  journal =       {Journal of Logic and Computation},
+  number =        {4},
+  pages =         {947--967},
+  title =         {Syllogistic Logics with Verbs},
+  volume =        {20},
+  year =          {2010},
+    doi = {10.1093/logcom/exn086},
+}
+
+@incollection{moss_ls:2010a,
+  address =       {Berlin},
+  author =        {Moss, Lawrence S.},
+  booktitle =     {Fields of Logic and Computation. Essays Dedicated to
+                   Yuri Gurevich on the Occasion of His 70th Birthday},
+  editor =        {Blass, Andreas and Dersowitz, Nachum and
+                   Reisig, Wolfgang},
+  pages =         {538--564},
+  publisher =     {Springer Verlag},
+  title =         {Logics for Two Fragments beyond the Syllogistic
+                   Boundary},
+  year =          {2010},
+}
+
+@incollection{moss_ls:2010b,
+  address =       {Berlin},
+  author =        {Moss, Lawrence S.},
+  booktitle =     {Logic, Language and Meaning. 17th Amsterdam
+                   Colloquium, Amsterdam, The Netherlands, December
+                   16-18, 2009. Revised Selected Papers},
+  pages =         {84--93},
+  publisher =     {Springer Verlag},
+  title =         {Natural Logic and Semantics},
+  year =          {2010},
+}
+
+@Article{moss_ls:2011,
+  author  = {Moss, Lawrence S.},
+  journal = {Journal of Logic, Language, and Information},
+  title   = {Syllogistic Logics With Comparative Adjectives},
+  year    = {2011},
+  number  = {3},
+  pages   = {397--417},
+  volume  = {20},
+  doi     = {10.1007/s10849-011-9137-x},
+}
+
+@incollection{moss_ls:2015,
+  address =       {Oxford},
+  author =        {Moss, Lawrence S.},
+  booktitle =     {The Handbook of Contemporary Semantic Theory},
+  edition =       {2},
+  editor =        {Lappin, Shalom and Fox, Chris},
+  note =          {first edition: \citet{lappin:1996}},
+  pages =         {561--592},
+  publisher =     {John Wiley \& Sons, Inc.},
+  title =         {Natural Logic},
+  year =          {2015},
+}
+
+@incollection{moss_ls:2016,
+  address =       {Cham},
+  author =        {Moss, Lawrence S.},
+  booktitle =     {J. Michael Dunn on Information Based Logics},
+  editor =        {Bimb{\'o}, Katalin},
+  number =        {8},
+  pages =         {391--416},
+  publisher =     {Springer International Publishing},
+  series =        {Outstanding Contributions to Logic},
+  title =         {Syllogistic Logic with Cardinality Comparisons},
+  year =          {2016},
+}
+
+@article{moss_ls-topal:2020,
+  author =        {Moss, Lawrence S. and Topal, Sel{\c{c}}uk},
+  journal =       {The Review of Symbolic Logic},
+  number =        {1},
+  pages =         {1--22},
+  title =         {Syllogistic Logic with Cardinality Comparisons, On
+                   Infinite Sets},
+  volume =        {13},
+  year =          {2020},
+    doi = {10.1017/S1755020318000126},
+}
+
+@phdthesis{pavlovic:2017,
+  address =       {Budapest},
+  author =        {Pavlovi{\'c}, Edi},
+  school =        {Central European University},
+  type =          {PhD},
+  title =         {The Quantified Argument Calculus: An Inquiry into Its
+                   Logical Properties and Applications},
+  year =          {2017},
+}
+
+@Article{pavlovic-gratzl:2019,
+  author  = {Pavlovi{\'c}, Edi and Gratz, Norbert},
+  journal = {The Review of Symbolic Logic},
+  title   = {Proof-Theoretic Analysis of the Quantified Argument Calculus},
+  year    = {2019},
+  number  = {4},
+  pages   = {607--636},
+  volume  = {12},
+  doi     = {10.1017/s1755020318000114},
+}
+
+@Article{pratthartmann-moss:2009,
+  author  = {Pratt-Hartmann, Ian and Moss, Lawrence S.},
+  journal = {The Review of Symbolic Logic},
+  title   = {Logics for the Relational Syllogistic},
+  year    = {2009},
+  number  = {4},
+  pages   = {647--683},
+  volume  = {2},
+  doi     = {10.1017/s1755020309990086},
+}
+
+@Article{raab_j:2018,
+  author  = {Raab, Jonas},
+  journal = {History and Philosophy of Logic},
+  title   = {Aristotle, Logic, and QUARC},
+  year    = {2018},
+  number  = {4},
+  pages   = {305--340},
+  volume  = {39},
+  doi     = {10.1080/01445340.2018.1467198},
+}
+
+@book{sommers_f:1982,
+  address =       {Oxford},
+  author =        {Sommers, Fred},
+  publisher =     {Oxford University Press},
+  title =         {The Logic of Natural Language},
+  year =          {1982},
+}
+
+@Article{strawson_pf:1950,
+  author  = {Strawson, Peter Frederick},
+  journal = {Mind},
+  title   = {On Referring},
+  year    = {1950},
+  note    = {reprinted, with some added footnotes, in \citet[1--20]{strawson_pf:2004}},
+  number  = {235},
+  pages   = {320--344},
+  volume  = {59},
+  doi     = {10.2307/2266359},
+}
+
+@book{strawson_pf:1952,
+  address =       {London},
+  author =        {Strawson, Peter Frederick},
+  publisher =     {Methuen \& Co.},
+  title =         {Introduction to Logical Theory},
+  year =          {1952},
+}
+
+@book{geach_pt:1980,
+  address =       {Ithaca, New York},
+  author =        {Geach, Peter Thomas},
+  edition =       {3},
+  note =          {first edition: \citet{geach_pt:1962}},
+  publisher =     {Cornell University Press},
+  title =         {Reference and Generality, an examination of some
+                   medieval and modern theories},
+  year =          {1980},
+}
+
+@book{mccall_s:1967,
+  address =       {Oxford},
+  booktitle =     {Polish Logic 1920--1939},
+  editor =        {McCall, Storrs},
+  publisher =     {Oxford University Press},
+  title =         {Polish Logic 1920--1939},
+  year =          {1967},
+}
+
+@book{lappin-fox:2015,
+  address =       {Oxford},
+  booktitle =     {The Handbook of Contemporary Semantic Theory},
+  edition =       {2},
+  editor =        {Lappin, Shalom and Fox, Chris},
+  note =          {first edition: \citet{lappin:1996}},
+  publisher =     {John Wiley \& Sons, Inc.},
+  title =         {The Handbook of Contemporary Semantic Theory},
+  year =          {2015},
+}
+
+@book{lappin:1996,
+  address =       {Oxford},
+  booktitle =     {The Handbook of Contemporary Semantic Theory},
+  editor =        {Lappin, Shalom},
+  publisher =     {Basil Blackwell Publishers},
+  title =         {The Handbook of Contemporary Semantic Theory},
+  year =          {1996},
+}
+
+@book{lemmon:1965,
+  address =       {London},
+  author =        {Lemmon, Edward John},
+  publisher =     {Thomas Nelson and Sons Ltd.},
+  title =         {Beginning Logic},
+  year =          {1965},
+}
+
+@book{flew_an:1956,
+  address =       {London},
+  booktitle =     {Essays in Conceptual Analysis},
+  editor =        {Flew, Antony Garrard Newton},
+  publisher =     {MacMillan Publishing Co.},
+  title =         {Essays in Conceptual Analysis},
+  year =          {1956},
+}
+
+@book{caton_ce:1963,
+  address =       {Urbana, Illinois},
+  booktitle =     {Philosophy and Ordinary Language},
+  editor =        {Caton, Charles E.},
+  publisher =     {University of Illinois Press},
+  title =         {Philosophy and Ordinary Language},
+  year =          {1963},
+}
+
+@book{klemke_ed:1970,
+  address =       {Urbana, Illinois},
+  booktitle =     {Essays on Russell},
+  editor =        {Klemke, Elmer Daniel},
+  publisher =     {University of Illinois Press},
+  title =         {Essays on Russell},
+  year =          {1970},
+}
+
+@book{strawson_pf:1971,
+  address =       {London},
+  author =        {Strawson, Peter Frederick},
+  booktitle =     {Logico-Linguistic Papers},
+  note =          {reprinted as \citet{strawson_pf:2004}},
+  publisher =     {Methuen \& Co.},
+  title =         {Logico-Linguistic Papers},
+  year =          {1971},
+}
+
+@book{moore_aw:1993,
+  address =       {Oxford},
+  booktitle =     {Meaning and Reference},
+  editor =        {Moore, Adrian W.},
+  publisher =     {Oxford University Press},
+  series =        {Oxford Readings in Philosophy},
+  title =         {Meaning and Reference},
+  year =          {1993},
+}
+
+@book{strawson_pf:2004,
+  address =       {Aldershot, Hampshire},
+  booktitle =     {Logico-Linguistic Papers},
+  edition =       {2},
+  editor =        {Strawson, Peter Frederick},
+  publisher =     {Ashgate Publishing Limited},
+  title =         {Logico-Linguistic Papers},
+  year =          {2004},
+}
+
+@book{hendricks_vf-etal:2004,
+  address =       {Berlin},
+  booktitle =     {First-Order Logic Revisited},
+  editor =        {Hendricks, Vincent F. and Neuhaus, Fabian and
+                   Pedersen, Stig Andur and Scheffler, Uwe and
+                   Wansing, Heinrich},
+  number =        {12},
+  publisher =     {Logos Verlag},
+  series =        {Logische Philosophie},
+  title =         {First-Order Logic Revisited},
+  year =          {2004},
+}
+
+@book{vonheusinger-etal:2011,
+  address =       {Berlin},
+  booktitle =     {Semantics: An International Handbook of Natural
+                   Language Meaning. Volume 2},
+  editor =        {von Heusinger, Klaus and Maienborn, Claudia and
+                   Portner, Paul},
+  number =        {33.2},
+  publisher =     {de Gruyter Monton},
+  series =        {Handbooks of Linguistics and Communication Science},
+  title =         {Semantics: An International Handbook of Natural
+                   Language Meaning. Volume 2},
+  year =          {2011},
+}
+
+@book{blass-etal:2010,
+  address =       {Berlin},
+  booktitle =     {Fields of Logic and Computation. Essays Dedicated to
+                   Yuri Gurevich on the Occasion of His 70th Birthday},
+  editor =        {Blass, Andreas and Dersowitz, Nachum and
+                   Reisig, Wolfgang},
+  publisher =     {Springer Verlag},
+  title =         {Fields of Logic and Computation. Essays Dedicated to
+                   Yuri Gurevich on the Occasion of His 70th Birthday},
+  year =          {2010},
+}
+
+@book{aloni-etal:2010,
+  address =       {Berlin},
+  author =        {Aloni, Maria and Bastiaanse, Harald and
+                   de Jager, Tikitu and Schulz, Katrin},
+  booktitle =     {Logic, Language and Meaning. 17th Amsterdam
+                   Colloquium, Amsterdam, The Netherlands, December
+                   16-18, 2009. Revised Selected Papers},
+  publisher =     {Springer Verlag},
+  title =         {Logic, Language and Meaning. 17th Amsterdam
+                   Colloquium, Amsterdam, The Netherlands, December
+                   16-18, 2009. Revised Selected Papers},
+  year =          {2010},
+}
+
+@book{bimbo:2016,
+  address =       {Cham},
+  booktitle =     {J. Michael Dunn on Information Based Logics},
+  editor =        {Bimb{\'o}, Katalin},
+  number =        {8},
+  publisher =     {Springer International Publishing},
+  series =        {Outstanding Contributions to Logic},
+  title =         {J. Michael Dunn on Information Based Logics},
+  year =          {2016},
+}
+
+@book{chakraborty_mk-etal:2008,
+  address =       {London},
+  booktitle =     {Logic, Navya-Ny{\=a}ya \& Applications. Hommage to
+                   Bimal Krishna Matilal},
+  editor =        {Chakraborty, Mihir K. and Löwe, Benedikt and
+                   Nath Mitra, Madhabendra and Surakkai, Sundar},
+  publisher =     {College Publications},
+  series =        {Studies in Logic},
+  title =         {Logic, Navya-Ny{\=a}ya \& Applications. Hommage to
+                   Bimal Krishna Matilal},
+  year =          {2008},
+}
+
+@Comment{jabref-meta: databaseType:bibtex;}


### PR DESCRIPTION
Minor changes to the script: the info message only printed once (if processing several files), import bibparsertex conditional on --source.

Adds documentation, reorganizes folder. 